### PR TITLE
Add training utilities and expanded PINN examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,28 +14,34 @@ pip install -r requirements.txt
 
 ## Usage
 
-The package exposes a minimal `KFAC` optimizer and helper utilities for building
-PINNs. See the notebooks in the `examples/` directory for demonstrations.
+The package exposes a minimal `KFAC` optimizer, utilities for constructing
+PINNs and a small training loop helper.  See the notebooks in the
+`examples/` directory for demonstrations.
 
 ```python
 import jax
 import jax.numpy as jnp
 import equinox as eqx
 
-from kfac_pinn import KFAC, pinn
+from kfac_pinn import KFAC, pinn, training
 
 model = pinn.make_mlp()
 opt = KFAC(lr=1e-2)
-state = opt.init(model, jnp.ones((10, 1)))
 
-# define your physics loss here
+def loss_fn(m, x):
+    res = pinn.pinn_residual(m, x, lambda x: jnp.zeros_like(x))
+    return jnp.mean(res ** 2)
+
+data = [jnp.linspace(0, 1, 32).reshape(-1, 1)] * 100
+model, state = training.train(model, opt, loss_fn, data, steps=100)
 ```
 
 ## Examples
 
-Two example notebooks are provided:
+Several example notebooks are provided:
 
-- `examples/basic_pinn.ipynb` – Training a simple PINN using KFAC.
+- `examples/basic_pinn.ipynb` – Train a simple PINN solving a Poisson equation.
 - `examples/custom_network.ipynb` – Demonstrates creating a custom network.
+- `examples/train_poisson.ipynb` – Full PINN training loop using the helper utilities.
 
 Run them with Jupyter to see the optimizer in action.

--- a/examples/basic_pinn.ipynb
+++ b/examples/basic_pinn.ipynb
@@ -9,20 +9,47 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We solve the 1D Poisson equation $u''(x) = -\pi^2\sin(\pi x)$ with zero boundary conditions."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "import jax\n",
     "import jax.numpy as jnp\n",
-    "from jax import random\n",
-    "import equinox as eqx\n",
-    "from kfac_pinn import KFAC, pinn\n",
+    "from kfac_pinn import KFAC, pinn, training\n",
     "\n",
-    "key = random.PRNGKey(0)\n",
+    "key = jax.random.PRNGKey(0)\n",
     "model = pinn.make_mlp(key=key)\n",
-    "opt = KFAC(lr=1e-3)\n",
-    "state = opt.init(model, jnp.ones((10, 1)))\n"
+    "\n",
+    "def rhs(x):\n",
+    "    return (jnp.pi ** 2) * jnp.sin(jnp.pi * x)\n",
+    "\n",
+    "def exact(x):\n",
+    "    return jnp.sin(jnp.pi * x)\n",
+    "\n",
+    "def loss_fn(m, x):\n",
+    "    interior = pinn.interior_loss(m, x, rhs)\n",
+    "    bc = pinn.boundary_loss(m, jnp.array([[0.0], [1.0]]), exact)\n",
+    "    return interior + bc\n",
+    "\n",
+    "data = [jax.random.uniform(key, (128, 1)) for _ in range(100)]\n",
+    "model, state = training.train(model, KFAC(lr=1e-2), loss_fn, data, steps=100)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model(jnp.linspace(0, 1, 5).reshape(-1, 1))\n"
    ]
   }
  ],

--- a/examples/custom_network.ipynb
+++ b/examples/custom_network.ipynb
@@ -4,8 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Custom network\n",
-    "Demonstrates creating a custom network for use with the KFAC optimizer."
+    "# Custom network example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Defining your own network and training it with the optimiser."
    ]
   },
   {
@@ -17,7 +23,7 @@
     "import jax\n",
     "import jax.numpy as jnp\n",
     "import equinox as eqx\n",
-    "from kfac_pinn import KFAC\n",
+    "from kfac_pinn import KFAC, training\n",
     "\n",
     "class Net(eqx.Module):\n",
     "    linear: eqx.nn.Linear\n",
@@ -28,8 +34,13 @@
     "\n",
     "key = jax.random.PRNGKey(0)\n",
     "model = Net(key)\n",
-    "opt = KFAC(lr=1e-3)\n",
-    "state = opt.init(model, jnp.ones((10, 1)))\n"
+    "\n",
+    "def loss_fn(m, x):\n",
+    "    return jnp.mean((m(x) - jnp.sin(x)) ** 2)\n",
+    "\n",
+    "data = [jax.random.uniform(key, (16, 1)) for _ in range(50)]\n",
+    "opt = KFAC(lr=1e-2)\n",
+    "model, state = training.train(model, opt, loss_fn, data, steps=50)\n"
    ]
   }
  ],

--- a/examples/train_poisson.ipynb
+++ b/examples/train_poisson.ipynb
@@ -1,0 +1,51 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Poisson equation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "from kfac_pinn import KFAC, pinn, training\n",
+    "\n",
+    "def rhs(x):\n",
+    "    return (jnp.pi ** 2) * jnp.sin(jnp.pi * x)\n",
+    "\n",
+    "def exact(x):\n",
+    "    return jnp.sin(jnp.pi * x)\n",
+    "\n",
+    "key = jax.random.PRNGKey(0)\n",
+    "model = pinn.make_mlp(key=key)\n",
+    "opt = KFAC(lr=1e-2)\n",
+    "\n",
+    "def loss_fn(m, x):\n",
+    "    return pinn.interior_loss(m, x, rhs) + pinn.boundary_loss(m, jnp.array([[0.0],[1.0]]), exact)\n",
+    "\n",
+    "data = [jax.random.uniform(key, (64,1)) for _ in range(200)]\n",
+    "model, state = training.train(model, opt, loss_fn, data, steps=200)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/kfac_pinn/__init__.py
+++ b/kfac_pinn/__init__.py
@@ -7,5 +7,6 @@ basic optimizer and helper routines built on top of ``jax`` and ``equinox``.
 
 from .kfac import KFAC
 from . import pinn
+from . import training
 
-__all__ = ["KFAC", "pinn"]
+__all__ = ["KFAC", "pinn", "training"]

--- a/kfac_pinn/pinn.py
+++ b/kfac_pinn/pinn.py
@@ -9,17 +9,34 @@ import equinox as eqx
 
 
 def make_mlp(width: int = 32, depth: int = 2, key: jax.random.PRNGKey = jax.random.PRNGKey(0)):
+    """Construct a simple fully connected network."""
     layers = []
+    k1 = key
     for _ in range(depth):
-        layers.append(eqx.nn.Linear(width, width, key=key))
+        k1, k2 = jax.random.split(k1)
+        layers.append(eqx.nn.Linear(width, width, key=k1))
         layers.append(jax.nn.tanh)
-    layers.append(eqx.nn.Linear(width, 1, key=key))
+    layers.append(eqx.nn.Linear(width, 1, key=k2))
     return eqx.nn.Sequential(layers)
 
 
 def pinn_residual(model: eqx.Module, points: jnp.ndarray, rhs: Callable[[jnp.ndarray], jnp.ndarray]):
+    """Compute the PDE residual ``L(model)(x) - rhs(x)`` at ``points``."""
+
     def laplace(u, x):
-        grads = jax.grad(lambda xx: model(xx).sum())(x)
+        grads = jax.grad(lambda xx: u(xx).sum())(x)
         return jax.grad(lambda xx: grads.sum())(x)
 
     return laplace(model, points) - rhs(points)
+
+
+def boundary_loss(model: eqx.Module, points: jnp.ndarray, exact: Callable[[jnp.ndarray], jnp.ndarray]):
+    """Squared error on boundary conditions."""
+    preds = model(points)
+    return jnp.mean((preds - exact(points)) ** 2)
+
+
+def interior_loss(model: eqx.Module, points: jnp.ndarray, rhs: Callable[[jnp.ndarray], jnp.ndarray]):
+    """Squared residual of the PDE inside the domain."""
+    res = pinn_residual(model, points, rhs)
+    return jnp.mean(res ** 2)

--- a/kfac_pinn/training.py
+++ b/kfac_pinn/training.py
@@ -1,0 +1,38 @@
+"""Training helpers for Physics-Informed Neural Networks."""
+
+from __future__ import annotations
+
+from typing import Callable, Iterable, Tuple
+
+import jax
+import jax.numpy as jnp
+import equinox as eqx
+
+from .kfac import KFAC, KFACState
+
+
+def train_step(model: eqx.Module, opt: KFAC, loss_fn: Callable[[eqx.Module, Tuple[jnp.ndarray, ...]], jnp.ndarray], batch, state: KFACState):
+    """Apply one optimisation step."""
+    return opt.step(model, loss_fn, batch, state)
+
+
+def train(model: eqx.Module, opt: KFAC, loss_fn: Callable[[eqx.Module, Tuple[jnp.ndarray, ...]], jnp.ndarray], data_iter: Iterable, steps: int):
+    """Simple training loop.
+
+    Parameters
+    ----------
+    model:
+        The neural network to optimise.
+    opt:
+        Instance of :class:`KFAC`.
+    loss_fn:
+        Function taking ``(model, batch)`` and returning a scalar loss.
+    data_iter:
+        Iterable yielding batches of training data.
+    steps:
+        Number of optimisation steps.
+    """
+    state = opt.init(model)
+    for step, batch in zip(range(steps), data_iter):
+        model, state = train_step(model, opt, loss_fn, batch, state)
+    return model, state


### PR DESCRIPTION
## Summary
- add simple diagonal KFAC-like optimizer implementation
- add training helper module
- enhance PINN utilities with residual and loss helpers
- update notebooks to demonstrate training
- add Poisson training example
- refresh README with new usage and examples

## Testing
- `python -m compileall -q kfac_pinn`