### PR TITLE
Enhance PINN utilities and add 2D Poisson example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,17 @@ Clone the repository and install the requirements:
 pip install -r requirements.txt
 ```
 
+Alternatively install the package in editable mode using `pyproject.toml`:
+
+```bash
+pip install -e .
+```
+
 ## Usage
 
 The package exposes a minimal `KFAC` optimizer, utilities for constructing
-PINNs and a small training loop helper.  See the notebooks in the
-`examples/` directory for demonstrations.
+PINNs, PDE helper functions and a small training loop helper. See the
+notebooks in the `examples/` directory for demonstrations.
 
 ```python
 import jax
@@ -40,8 +46,9 @@ model, state = training.train(model, opt, loss_fn, data, steps=100)
 
 Several example notebooks are provided:
 
-- `examples/basic_pinn.ipynb` – Train a simple PINN solving a Poisson equation.
+- `examples/basic_pinn.ipynb` – Train a 1D Poisson PINN.
 - `examples/custom_network.ipynb` – Demonstrates creating a custom network.
-- `examples/train_poisson.ipynb` – Full PINN training loop using the helper utilities.
+- `examples/train_poisson.ipynb` – Full 1D training loop.
+- `examples/poisson_2d.ipynb` – New example solving a 2D Poisson problem.
 
 Run them with Jupyter to see the optimizer in action.

--- a/examples/basic_pinn.ipynb
+++ b/examples/basic_pinn.ipynb
@@ -23,10 +23,10 @@
    "source": [
     "import jax\n",
     "import jax.numpy as jnp\n",
-    "from kfac_pinn import KFAC, pinn, training\n",
+    "from kfac_pinn import KFAC, pinn, pdes, training\n",
     "\n",
     "key = jax.random.PRNGKey(0)\n",
-    "model = pinn.make_mlp(key=key)\n",
+    "model = pinn.make_mlp(in_dim=1, key=key)\n",
     "\n",
     "def rhs(x):\n",
     "    return (jnp.pi ** 2) * jnp.sin(jnp.pi * x)\n",
@@ -39,7 +39,7 @@
     "    bc = pinn.boundary_loss(m, jnp.array([[0.0], [1.0]]), exact)\n",
     "    return interior + bc\n",
     "\n",
-    "data = [jax.random.uniform(key, (128, 1)) for _ in range(100)]\n",
+    "data = [pdes.sample_interior(key, jnp.array([0.0]), jnp.array([1.0]), 128) for _ in range(100)]\n",
     "model, state = training.train(model, KFAC(lr=1e-2), loss_fn, data, steps=100)\n"
    ]
   },

--- a/examples/poisson_2d.ipynb
+++ b/examples/poisson_2d.ipynb
@@ -1,0 +1,71 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 2D Poisson equation demo",
+    "\n",
+    "Solve $\\Delta u(x,y) = -2\\pi^2 \sin(\\pi x) \sin(\\pi y)$ with zero Dirichlet boundary conditions using the `kfac_pinn` package."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "from kfac_pinn import KFAC, pinn, pdes, training\n",
+    "\n",
+    "def rhs(x):\n",
+    "    return -2 * (jnp.pi ** 2) * jnp.sin(jnp.pi * x[:,0]) * jnp.sin(jnp.pi * x[:,1])\n",
+    "\n",
+    "def exact(x):\n",
+    "    return jnp.sin(jnp.pi * x[:,0]) * jnp.sin(jnp.pi * x[:,1])\n",
+    "\n",
+    "key = jax.random.PRNGKey(0)\n",
+    "model = pinn.make_mlp(width=64, depth=3, key=key)\n",
+    "opt = KFAC(lr=1e-2)\n",
+    "\n",
+    "def loss_fn(m, batch):\n",
+    "    interior = pinn.interior_loss(m, batch, rhs)\n",
+    "    bc_pts = jnp.concatenate([\n",
+    "        pdes.sample_boundary(key, jnp.array([0.0,0.0]), jnp.array([1.0,1.0]), 50)\n",
+    "    ], axis=0)\n",
+    "    bc = pinn.boundary_loss(m, bc_pts, exact)\n",
+    "    return interior + bc\n",
+    "\n",
+    "data = [pdes.sample_interior(key, jnp.array([0.0,0.0]), jnp.array([1.0,1.0]), 128) for _ in range(100)]\n",
+    "model, state = training.train(model, opt, loss_fn, data, steps=100)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# evaluate solution at a grid of points\n",
+    "grid_x, grid_y = jnp.meshgrid(jnp.linspace(0,1,10), jnp.linspace(0,1,10))\n",
+    "pts = jnp.stack([grid_x.ravel(), grid_y.ravel()], axis=-1)\n",
+    "pred = model(pts).reshape(grid_x.shape)\n",
+    "pred\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/train_poisson.ipynb
+++ b/examples/train_poisson.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "import jax\n",
     "import jax.numpy as jnp\n",
-    "from kfac_pinn import KFAC, pinn, training\n",
+    "from kfac_pinn import KFAC, pinn, pdes, training\n",
     "\n",
     "def rhs(x):\n",
     "    return (jnp.pi ** 2) * jnp.sin(jnp.pi * x)\n",
@@ -24,13 +24,13 @@
     "    return jnp.sin(jnp.pi * x)\n",
     "\n",
     "key = jax.random.PRNGKey(0)\n",
-    "model = pinn.make_mlp(key=key)\n",
+    "model = pinn.make_mlp(in_dim=1, key=key)\n",
     "opt = KFAC(lr=1e-2)\n",
     "\n",
     "def loss_fn(m, x):\n",
     "    return pinn.interior_loss(m, x, rhs) + pinn.boundary_loss(m, jnp.array([[0.0],[1.0]]), exact)\n",
     "\n",
-    "data = [jax.random.uniform(key, (64,1)) for _ in range(200)]\n",
+    "data = [pdes.sample_interior(key, jnp.array([0.0]), jnp.array([1.0]), 64) for _ in range(200)]\n",
     "model, state = training.train(model, opt, loss_fn, data, steps=200)\n"
    ]
   }

--- a/kfac_pinn/__init__.py
+++ b/kfac_pinn/__init__.py
@@ -5,8 +5,11 @@ optimizer for Physics-Informed Neural Networks (PINNs). This package exposes a
 basic optimizer and helper routines built on top of ``jax`` and ``equinox``.
 """
 
+__version__ = "0.1.0"
+
 from .kfac import KFAC
 from . import pinn
+from . import pdes
 from . import training
 
-__all__ = ["KFAC", "pinn", "training"]
+__all__ = ["KFAC", "pinn", "pdes", "training", "__version__"]

--- a/kfac_pinn/pdes.py
+++ b/kfac_pinn/pdes.py
@@ -1,0 +1,43 @@
+"""PDE-related helper utilities for PINNs."""
+
+from __future__ import annotations
+
+from typing import Callable
+import jax
+import jax.numpy as jnp
+import equinox as eqx
+
+
+def laplacian(model: Callable[[jnp.ndarray], jnp.ndarray], x: jnp.ndarray) -> jnp.ndarray:
+    """Compute the Laplacian of ``model`` at ``x``.
+
+    This uses automatic differentiation to evaluate the trace of the Hessian of
+    the model output with respect to ``x``. ``x`` can be a single point of shape
+    ``(dim,)`` or a batch of points ``(batch, dim)``.
+    """
+
+    def single_point(xx):
+        def scalar_fn(xp):
+            return jnp.sum(model(xp))
+
+        hess = jax.hessian(scalar_fn)(xx)
+        return jnp.trace(hess)
+
+    return jax.vmap(single_point)(x) if x.ndim > 1 else single_point(x)
+
+
+def sample_interior(key: jax.random.PRNGKey, domain_min: jnp.ndarray, domain_max: jnp.ndarray, num: int) -> jnp.ndarray:
+    """Sample ``num`` points uniformly from the interior of a hyper-rectangle."""
+    dim = domain_min.shape[0]
+    pts = jax.random.uniform(key, (num, dim))
+    return domain_min + (domain_max - domain_min) * pts
+
+
+def sample_boundary(key: jax.random.PRNGKey, domain_min: jnp.ndarray, domain_max: jnp.ndarray, num: int) -> jnp.ndarray:
+    """Sample ``num`` points uniformly from the boundary of a hyper-rectangle."""
+    dim = domain_min.shape[0]
+    pts = jax.random.uniform(key, (num, dim))
+    face = jax.random.randint(key, (num,), 0, dim)
+    pts = domain_min + (domain_max - domain_min) * pts
+    pts = pts.at[jnp.arange(num), face].set(domain_min[face])
+    return pts

--- a/kfac_pinn/pinn.py
+++ b/kfac_pinn/pinn.py
@@ -7,36 +7,38 @@ import jax
 import jax.numpy as jnp
 import equinox as eqx
 
+from . import pdes
 
-def make_mlp(width: int = 32, depth: int = 2, key: jax.random.PRNGKey = jax.random.PRNGKey(0)):
+
+def make_mlp(in_dim: int = 1, width: int = 32, depth: int = 2, key: jax.random.PRNGKey = jax.random.PRNGKey(0)):
     """Construct a simple fully connected network."""
     layers = []
     k1 = key
-    for _ in range(depth):
-        k1, k2 = jax.random.split(k1)
+    k1, k2 = jax.random.split(k1)
+    layers.append(eqx.nn.Linear(in_dim, width, key=k1))
+    layers.append(eqx.nn.Lambda(jax.nn.tanh))
+    for _ in range(depth - 1):
+        k1, k2 = jax.random.split(k2)
         layers.append(eqx.nn.Linear(width, width, key=k1))
-        layers.append(jax.nn.tanh)
+        layers.append(eqx.nn.Lambda(jax.nn.tanh))
     layers.append(eqx.nn.Linear(width, 1, key=k2))
     return eqx.nn.Sequential(layers)
 
 
 def pinn_residual(model: eqx.Module, points: jnp.ndarray, rhs: Callable[[jnp.ndarray], jnp.ndarray]):
-    """Compute the PDE residual ``L(model)(x) - rhs(x)`` at ``points``."""
+    """Compute the PDE residual ``Δu(x) - rhs(x)`` at ``points``."""
 
-    def laplace(u, x):
-        grads = jax.grad(lambda xx: u(xx).sum())(x)
-        return jax.grad(lambda xx: grads.sum())(x)
-
-    return laplace(model, points) - rhs(points)
+    lap = pdes.laplacian(model, points)
+    return lap - rhs(points)
 
 
 def boundary_loss(model: eqx.Module, points: jnp.ndarray, exact: Callable[[jnp.ndarray], jnp.ndarray]):
     """Squared error on boundary conditions."""
-    preds = model(points)
+    preds = jax.vmap(model)(points)
     return jnp.mean((preds - exact(points)) ** 2)
 
 
 def interior_loss(model: eqx.Module, points: jnp.ndarray, rhs: Callable[[jnp.ndarray], jnp.ndarray]):
     """Squared residual of the PDE inside the domain."""
-    res = pinn_residual(model, points, rhs)
+    res = jax.vmap(lambda x: pinn_residual(model, x, rhs))(points)
     return jnp.mean(res ** 2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "kfac_pinn"
+version = "0.1.0"
+description = "KFAC optimizer utilities for Physics-Informed Neural Networks"
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = [
+    "jax",
+    "jaxlib",
+    "equinox",
+    "numpy",
+    "matplotlib",
+]
+
+[project.urls]
+homepage = "https://example.com"


### PR DESCRIPTION
## Summary
- add `pdes` module with Laplacian and sampling helpers
- expose version and new module in package init
- fix `make_mlp` and losses for batched inputs
- document package installation via `pyproject.toml`
- update example notebooks and add new 2D Poisson demo

## Testing
- `python -m compileall -q kfac_pinn`
- `python - <<'EOF'
import kfac_pinn; print(kfac_pinn.__version__)
EOF`