### PR TITLE
Add forward-mode Laplacian utility

### DIFF
--- a/examples/forward_laplacian_demo.ipynb
+++ b/examples/forward_laplacian_demo.ipynb
@@ -1,0 +1,36 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Forward Laplacian Demo\n",
+    "This notebook demonstrates the new `forward_laplacian` utility in the `kfac_pinn` package."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jax, jax.numpy as jnp",
+    "from kfac_pinn.pdes import forward_laplacian",
+    "from kfac_pinn.pinn import make_mlp",
+    "\n",
+    "model = make_mlp()",
+    "x = jnp.array([[0.1, 0.2]])",
+    "print(forward_laplacian(model, x))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/kfac_pinn/pinn_kfac.py
+++ b/kfac_pinn/pinn_kfac.py
@@ -22,7 +22,7 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 
-from .pdes import laplacian
+from .pdes import forward_laplacian
 
 
 class LayerFactors(NamedTuple):
@@ -92,7 +92,7 @@ class PINNKFAC(eqx.Module):
 
         def interior_loss(p):
             m = eqx.combine(static, p)
-            lap = jax.vmap(lambda x: laplacian(m, x[None, :]))(interior)
+            lap = jax.vmap(lambda x: forward_laplacian(m, x[None, :]))(interior)
             res = lap.squeeze() - rhs_fn(interior)
             return 0.5 * jnp.mean(res**2)
 
@@ -214,7 +214,7 @@ def _factor_terms(model, params, pts, fn, interior: bool):
     m = eqx.combine(eqx.partition(model, eqx.is_array)[1], params)
     y, acts, pre, phi = _forward_cache(m, pts)
     if interior:
-        lap = jax.vmap(lambda x: laplacian(m, x[None, :]))(pts).squeeze()
+        lap = jax.vmap(lambda x: forward_laplacian(m, x[None, :]))(pts).squeeze()
         res = lap - fn(pts)
     else:
         res = y.squeeze() - fn(pts)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kfac_pinn"
-version = "0.2.0"
+version = "0.3.0"
 description = "KFAC optimizer utilities for Physics-Informed Neural Networks"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- implement a `forward_laplacian` helper to compute the Laplacian using JVPs
- use it inside `PINNKFAC` so the optimiser matches the algorithm more closely
- bump package version to 0.3.0
- add small demo notebook showing the new utility

## Testing
- `python -m compileall -q kfac_pinn`
- *(no tests found)*