### PR TITLE
Improve PINNKFAC utilities and fixes

### DIFF
--- a/examples/pinnkfac_training_loop.ipynb
+++ b/examples/pinnkfac_training_loop.ipynb
@@ -1,0 +1,13 @@
+{
+ "cells": [
+  {"cell_type": "markdown", "metadata": {}, "source": ["# PINNKFAC Training Loop Demo\n", "\n", "This notebook demonstrates using `pinn_train` from the `kfac_pinn` package to train a simple 1D Poisson PINN."]},
+  {"cell_type": "code", "metadata": {}, "source": ["import jax, jax.numpy as jnp, equinox as eqx\n", "from kfac_pinn import PINNKFAC, pinn, pdes, training\n", "\n", "key = jax.random.PRNGKey(0)\n", "model = pinn.make_mlp(key=key)\n", "opt = PINNKFAC(lr=1e-2, use_line_search=False)\n", "\n", "def rhs(x):\n    return (jnp.pi**2) * jnp.sin(jnp.pi * x)\n", "\n", "def bc(x):\n    return jnp.zeros_like(x)\n", "\n", "key_i, key_b = jax.random.split(key)\n", "interior_points = [pdes.sample_interior(key_i, jnp.array([0.0]), jnp.array([1.0]), 64)] * 100\n", "boundary_points = [jnp.array([[0.0], [1.0]])] * 100\n", "\n", "model, state = training.pinn_train(model, opt, rhs, bc, interior_points, boundary_points, steps=100)"]},
+  {"cell_type": "code", "metadata": {}, "source": ["res = pinn.pinn_residual(model, interior_points[0], rhs)\n", "print('Final interior residual', jnp.mean(res**2))"]}
+ ],
+ "metadata": {
+  "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+  "language_info": {"name": "python", "pygments_lexer": "ipython3"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/kfac_pinn/kfac.py
+++ b/kfac_pinn/kfac.py
@@ -69,6 +69,7 @@ class KFAC(eqx.Module):
     # ------------------------------------------------------------------
     # Core optimisation step
     # ------------------------------------------------------------------
+    @eqx.filter_jit
     def step(
         self,
         model: eqx.Module,

--- a/kfac_pinn/pinn_kfac.py
+++ b/kfac_pinn/pinn_kfac.py
@@ -634,6 +634,7 @@ class PINNKFAC(eqx.Module):
         return final_params_pytree, tuple(new_kfac_state_layers_list)
 
 
+    @eqx.filter_jit
     def step(
         self,
         model: eqx.Module,
@@ -877,7 +878,7 @@ def _standard_backward_pass(model: eqx.Module, pre_activations: List[jnp.ndarray
     else:
         g = grad_output
     linear_layer_indices = [i for i, l_obj in enumerate(model.layers) if isinstance(l_obj, eqx.nn.Linear)]
-    for idx_in_model_lists in reversed(range(len(linear_layer_indices)))):
+    for idx_in_model_lists in reversed(range(len(linear_layer_indices))):
         layer_object = _linear_layers(model)[idx_in_model_lists] 
         phi_l = act_derivatives[idx_in_model_lists] 
         g_s_l = g * phi_l 


### PR DESCRIPTION
## Summary
- fix `_standard_backward_pass` loop parenthesis
- jit compile `KFAC.step` and `PINNKFAC.step`
- add training helpers for PINNKFAC
- provide example notebook using new training loop

## Testing
- `pytest -q` *(fails: pytest not installed)*